### PR TITLE
Remove redundant instruction

### DIFF
--- a/week-04/04-tech-lab.adoc
+++ b/week-04/04-tech-lab.adoc
@@ -59,7 +59,6 @@ You have privileges to create issues, forks, and pull requests on both dp-course
 
 On Github, go to your account and go into the forked dp-course repository go into its Settings, scroll all the way down, and *delete* it. You will have to re-type the repository name and re-enter your password. 
 * Then, go to https://github.com/dm-academy/dp-course and copy the clone address and git clone DIRECTLY to your local `repos` directory on Google Cloud Shell. 
-* Do this also for https://github.com/dm-academy/dp-course. 
 
 You now have a repo that you can directly create issues, branches, and pull requests for. This is the most common way of managing collaboration with git and derivative platforms; forking is not as commonly used, especially in organizational contexts (it's mostly an open source thing).  
 


### PR DESCRIPTION
The instructions indicate cloning the same repo twice. I suspect this may have been a reference to cloning node-svc? Node-svc is now covered in a different part of the lab.