### PR TITLE
lab 03: node-svc naming issue #35

### DIFF
--- a/week-03/03-tech-lab.adoc
+++ b/week-03/03-tech-lab.adoc
@@ -95,15 +95,15 @@ Once you defined how your image should be built, run the following command insid
 
 [source,bash]
 ----
-$ docker build -t <yourGoogleID>/node-svc .
+$ docker build -t <yourGoogleID>/node-svc-v1 .
 ----
 
-The resulting image will be named `node-svc`.
+The resulting image will be named `node-svc-v1`.
 Find it in the list of your local images:
 
 [source,bash]
 ----
-$ docker images | grep node-svc
+$ docker images | grep node-svc-v1
 ----
 
 At your option, you can save your build command in a script, such as `build.sh`.
@@ -112,7 +112,7 @@ Now, run the container:
 
 [source,bash]
 ----
-docker run -d -p 8081:30100 level-research-289323/node-svc
+docker run -d -p 8081:30100 level-research-289323/node-svc-v1
 ----
 
 Notice the "8081:3000" syntax.

--- a/week-03/03-tech-lab.adoc
+++ b/week-03/03-tech-lab.adoc
@@ -95,15 +95,15 @@ Once you defined how your image should be built, run the following command insid
 
 [source,bash]
 ----
-$ docker build -t <yourGoogleID>/node-svc-v1 .
+$ docker build -t <yourGoogleID>/node-svc .
 ----
 
-The resulting image will be named `node-svc-v1`.
+The resulting image will be named `node-svc`.
 Find it in the list of your local images:
 
 [source,bash]
 ----
-$ docker images | grep node-svc-v1
+$ docker images | grep node-svc
 ----
 
 At your option, you can save your build command in a script, such as `build.sh`.
@@ -112,7 +112,7 @@ Now, run the container:
 
 [source,bash]
 ----
-docker run -d -p 8081:30100 level-research-289323/node-svc-v1
+docker run -d -p 8081:30100 level-research-289323/node-svc
 ----
 
 Notice the "8081:3000" syntax.

--- a/week-04/04-tech-lab.adoc
+++ b/week-04/04-tech-lab.adoc
@@ -78,7 +78,7 @@ IMPORTANT: You *cannot* directly push to master; I (or another administrator) ha
 
 == Github issues, branches, and pull requests
 
-Here is an overview of the following sections: 
+Here is an overview of the following sections: The following image is for dp-course. 
 
 image:images/overview.png[]
 


### PR DESCRIPTION
node-svc is better than node-svc-v1 for Container's name to set Github Actions.