### PR TITLE
Update 03-tech-lab.adoc

### DIFF
--- a/week-03/03-tech-lab.adoc
+++ b/week-03/03-tech-lab.adoc
@@ -558,7 +558,7 @@ In the last section, we were able to access the application's main URL. Also, at
 
 You'll quickly realize this is a set of often repeated actions. We're now ready for continuous delivery. Please review the following diagram:
 
-image:images/pipeline.png[]
+image:images/Pipeline.png[]
 
 === Continuous delivery 
 


### PR DESCRIPTION
In the "Updating the service: towards a true pipeline" section, clicking on the "pipeline" link results in a 404 Page not found error.
The URL is https://github.com/dm-academy/dp-course/blob/master/week-03/images/pipeline.png.
The actual image name is Pipeline.png